### PR TITLE
Cache importer incorrectly caches non-existant files

### DIFF
--- a/lib/sass-build-recommended.js
+++ b/lib/sass-build-recommended.js
@@ -18,8 +18,8 @@ const config = {
                 minify: false,
                 functions: [],
                 importers: [
-                    sassCacheImporter(),
-                    sassPackageImporter({ cwd: cwd })
+                    sassPackageImporter({ cwd: cwd }),
+                    sassCacheImporter()
                 ]
             },
             postcss: [

--- a/src/importers/cache-importer.ts
+++ b/src/importers/cache-importer.ts
@@ -48,5 +48,5 @@ export function sassCacheImporter( options: CacheImporterOptions = { cache: true
         return null;
     };
 
-    return <SassImporter>sassCacheImporter;
+    return <SassImporter> sassCacheImporter;
 }

--- a/src/importers/cache-importer.ts
+++ b/src/importers/cache-importer.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-const EMPTY_IMPORT = {};
+const EMPTY_IMPORT_RESULT = <LegacyImporterResult> {};
 
 export function sassCacheImporter( options: CacheImporterOptions = { cache: true } ) : SassImporter {
 
@@ -10,7 +10,7 @@ export function sassCacheImporter( options: CacheImporterOptions = { cache: true
         ? cache
         : new Set();
 
-    function sassCacheImporter( url: string, prev: string ) : null | LegacyImporterResult {
+    function sassCacheImporter( url: string, prev: string ) : LegacyImporterResult {
 
         // If previous file is stdin, then we are importing from a string
         if (prev === 'stdin') {
@@ -26,7 +26,7 @@ export function sassCacheImporter( options: CacheImporterOptions = { cache: true
         if ( fs.existsSync( file ) ) {
 
             if ( cache && imported.has( file ) ) {
-                return <LegacyImporterResult> EMPTY_IMPORT;
+                return EMPTY_IMPORT_RESULT;
             }
 
             imported.add( file );

--- a/src/importers/cache-importer.ts
+++ b/src/importers/cache-importer.ts
@@ -1,37 +1,40 @@
+import fs from 'fs';
 import path from 'path';
 
 const EMPTY_IMPORT = {};
 
-export function sassCacheImporter(options: CacheImporterOptions = { cache: true }) : SassImporter {
+export function sassCacheImporter( options: CacheImporterOptions = { cache: true } ) : SassImporter {
 
     const cache = options.cache;
     const imported : Set<string> = cache instanceof Set
         ? cache
         : new Set();
 
-    function sassCacheImporter(url: string, prev: string) : null | LegacyImporterResult {
+    function sassCacheImporter( url: string, prev: string ) : null | LegacyImporterResult {
 
+        // If previous file is stdin, then we are importing from a string
         if (prev === 'stdin') {
             return null;
         }
 
-        if (url.startsWith('~')) {
-            imported.add(url);
-            return null;
-        }
-
-        const file = path.resolve(path.join(
+        const file = path.resolve(
             path.dirname(prev),
             url
-        ));
+        );
 
-        if (cache && imported.has(file)) {
-            return <LegacyImporterResult>EMPTY_IMPORT;
+        // Only cache existing files
+        if ( fs.existsSync( file ) ) {
+
+            if ( cache && imported.has( file ) ) {
+                return <LegacyImporterResult> EMPTY_IMPORT;
+            }
+
+            imported.add( file );
+
+            return { file };
         }
 
-        imported.add(file);
-
-        return { file };
+        return null;
     }
     sassCacheImporter.name = 'sassCacheImporter';
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/importers/package-importer.ts
+++ b/src/importers/package-importer.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import path from 'path';
 import { pathToFileURL } from 'url';
 
@@ -16,17 +17,28 @@ export function sassPackageImporter( options?: PackageImporterOptions ) : SassIm
 
     function sassPackageImporter( url: string ) : LegacyImporterResult {
 
-        if ( !url.startsWith('~') ) {
+        // If the file exists, don't process it
+        if ( fs.existsSync( url ) ) {
             return null;
         }
 
+        // Remove leading tilde, if any
+        if ( url.startsWith('~') ) {
+            // eslint-disable-next-line no-param-reassign
+            url = url.slice(1);
+        }
+
         const file = path.resolve(
-            <string>cwd,
-            <string>nodeModules,
-            url.slice(1)
+            <string> cwd,
+            <string> nodeModules,
+            url
         );
 
-        return { file };
+        if ( fs.existsSync( file ) ) {
+            return { file };
+        }
+
+        return null;
     }
     sassPackageImporter.name = 'sassPackageImporter';
     sassPackageImporter.before = function( context: { cwd: string } ) : void {
@@ -35,18 +47,29 @@ export function sassPackageImporter( options?: PackageImporterOptions ) : SassIm
 
     sassPackageImporter.findFileUrl = function( url: string ) : null | URL {
 
-        if ( !url.startsWith('~') ) {
+        // If the file exists, don't process it
+        if ( fs.existsSync( url ) ) {
             return null;
         }
 
+        // Remove leading tilde, if any
+        if ( url.startsWith('~') ) {
+            // eslint-disable-next-line no-param-reassign
+            url = url.slice(1);
+        }
+
         const file = path.resolve(
-            <string>cwd,
-            <string>nodeModules,
-            url.slice(1)
+            <string> cwd,
+            <string> nodeModules,
+            url
         );
 
-        return pathToFileURL( file );
+        if ( fs.existsSync( file ) ) {
+            return pathToFileURL( file );
+        }
+
+        return null;
     };
 
-    return <SassImporter>sassPackageImporter;
+    return <SassImporter> sassPackageImporter;
 }

--- a/src/importers/package-importer.ts
+++ b/src/importers/package-importer.ts
@@ -14,7 +14,7 @@ export function sassPackageImporter( options?: PackageImporterOptions ) : SassIm
         nodeModules = nodeModules();
     }
 
-    function sassPackageImporter( url: string ) : null | LegacyImporterResult {
+    function sassPackageImporter( url: string ) : LegacyImporterResult {
 
         if ( !url.startsWith('~') ) {
             return null;

--- a/types/sass/sass-importer.d.ts
+++ b/types/sass/sass-importer.d.ts
@@ -4,10 +4,10 @@ declare type ModernImporterResult = {
     syntax?: 'css' | 'scss' | 'indented';
 };
 
-declare type LegacyImporterResult = { file: string } | { contents: string };
+declare type LegacyImporterResult = { file: string } | { contents: string } | null;
 
 declare type SassImporter = {
-    (url: string) : null | LegacyImporterResult;
+    (url: string) : LegacyImporterResult;
     name?: string;
     findFileUrl( url: string ) : null | URL;
     canonicalize?( url: string ) : null | URL;


### PR DESCRIPTION
Instead, cache important should return `null` (allow other importers to process) if the file is not found.